### PR TITLE
Use escape_once instead of escape

### DIFF
--- a/lib/liquid/autoescape/liquid_ext/variable.rb
+++ b/lib/liquid/autoescape/liquid_ext/variable.rb
@@ -27,7 +27,7 @@ module Liquid
       variable = Autoescape::TemplateVariable.from_liquid_variable(self)
       is_exempt = Autoescape.configuration.exemptions.apply?(variable)
 
-      @filters << [:escape, []] unless is_exempt
+      @filters << [:escape_once, []] unless is_exempt
       output = non_escaping_render(context)
       @filters.pop unless is_exempt
 

--- a/spec/functional/autoescape_tag_spec.rb
+++ b/spec/functional/autoescape_tag_spec.rb
@@ -125,6 +125,13 @@ describe "{% autoescape %}" do
         )
       end
 
+      it "does not double-escape variables assigned using assign" do
+        verify_template_output(
+          "{% assign variable = \"&\" %}{{ variable }}",
+          "&amp;"
+        )
+      end
+
     end
 
     context "with custom exemptions" do

--- a/spec/functional/autoescape_tag_spec.rb
+++ b/spec/functional/autoescape_tag_spec.rb
@@ -61,6 +61,13 @@ describe "{% autoescape %}" do
     )
   end
 
+  it "does not double-escape variables assigned using assign" do
+    verify_template_output(
+      "{% autoescape %}{% assign variable = \"&\" %}{{ variable }}{% endautoescape %}",
+      "&amp;"
+    )
+  end
+
   it "can be called multiple times" do
     verify_template_output(
       "{% autoescape %}{{ var }}{% endautoescape %} {{ var }} {% autoescape %}{{ var }}{% endautoescape %}",


### PR DESCRIPTION
Partial fix for https://github.com/Within3/liquid-autoescape/issues/1 .

Note that the real issue is https://github.com/Within3/liquid-autoescape/issues/2 . This patch does not fix it, only masks it.